### PR TITLE
Fix signed URL in api/v2

### DIFF
--- a/api/views.py
+++ b/api/views.py
@@ -176,7 +176,7 @@ def create_signed_request(mime_type, object_name, bucket_name):
     url = 'https://%s.s3.amazonaws.com/%s' % (bucket_name,
                                               object_name)
     signed_request = '%s?AWSAccessKeyId=%s&Expires=%s&Signature=%s' % \
-                     (url, settings.AWS_ACCESS_KEY_ID, expires, signature),
+                     (url, settings.AWS_ACCESS_KEY_ID, expires, signature)
 
     return signed_request
 


### PR DESCRIPTION
Z jakiegoś dzikiego powodu ktoś postawił przecinek w tym miejscu. To oznacza, że ``signed_requests`` stało się jednoelementową krotką. Natomiast potem ta krotka jest składowana na liście za pośrednictwiem "attach_file_internal" w "create_report_v2". 

W skutek tego przecinka odpowiedź "create_report_v2" składa się z klucza "ID" i listy "signed_requests" składającej się stale z wielu jednoelementowych list. Niepotrzebne są tu listy w liście, gdy wystarczy zwykła lista.