### PR TITLE
Improve Sentry configuration

### DIFF
--- a/pola/config/settings/production.py
+++ b/pola/config/settings/production.py
@@ -111,4 +111,7 @@ sentry_sdk.init(
     # If you wish to associate users to errors (assuming you are using
     # django.contrib.auth) you may enable sending PII data.
     send_default_pii=True,
+    dsn=env.str('SENTRY_DSN'),  # noqa: F405
+    release=env.str('RELEASE_SHA'),  # noqa: F405
+    traces_sample_rate=env.float('SENTRY_TRACES_SAMPLE_RATE', default=0),  # noqa: F405
 )


### PR DESCRIPTION
Cześć.

Ja trochę poprawiłem konfiguracje Sentry:
- Sentry jest teraz wymagane,
- Przekazujemy informacje na temat obrazu Docker, więc łatwiej będzie śledzić, czy pojawiła się regresja,
- Mamy możliwość opcjonalnie skonfigurowania zbierania metryk wydajnościowych.

Pozdrawiam,
Kamil Breguła