### PR TITLE
Remove disk clean-up

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -27,7 +27,6 @@ jobs:
     steps:
       - name: "Checkout ${{ github.ref }} ( ${{ github.sha }} )"
         uses: actions/checkout@v2
-      - run: docker system prune -a -f
       - name: "Login to Github Docker Registry"
         run: ./scripts/docker_login_github.sh
       - run: docker images


### PR DESCRIPTION
Cześć,

Ten krok trwa zbyt dużo, a w sumie to my nie mamy problemów z zbyt małym dyskiem, więc możemy to bezpiecznie usunąć.

Wcześniej cały trwał 4m 56s, a teraz 3m 36s, więc wydaje się, żę warto się tego pozbyć.

Pozdrawiam.