### PR TITLE
Disable AI requests and remove read AI pics endpoint

### DIFF
--- a/pola/logic_ai.py
+++ b/pola/logic_ai.py
@@ -15,8 +15,13 @@ preview_texts = [
     'Rozwijaj z nami Polę!',
 ]
 
+ENABLE_AI_PICS_REQUEST = False
+
 
 def add_ask_for_pics(product, result):
+    if not ENABLE_AI_PICS_REQUEST:
+        return result
+
     if (
         product
         and product.name

--- a/pola/rpc_api/tests/test_urls.py
+++ b/pola/rpc_api/tests/test_urls.py
@@ -4,7 +4,6 @@ from test_plus import TestCase
 
 class TestApiUrls(TestCase):
     def test_should_render(self):
-        self.assertEqual("/a/v3/get_ai_pics", reverse("api:get_ai_pics"))
         self.assertEqual("/a/v3/add_ai_pics", reverse("api:add_ai_pics"))
         # API v3
         self.assertEqual("/a/v3/get_by_code", reverse("api:get_by_code_v3"))

--- a/pola/rpc_api/urls.py
+++ b/pola/rpc_api/urls.py
@@ -3,7 +3,6 @@ from django.conf.urls import url
 from . import views
 
 urlpatterns = [
-    url(regex=r'v3/get_ai_pics$', view=views.get_ai_pics, name="get_ai_pics"),
     url(regex=r'v3/add_ai_pics$', view=views.add_ai_pics, name="add_ai_pics"),
     # API v3
     url(regex=r'v3/get_by_code$', view=views.get_by_code_v3, name="get_by_code_v3"),

--- a/pola/rpc_api/views.py
+++ b/pola/rpc_api/views.py
@@ -7,8 +7,6 @@ from datetime import timedelta
 import boto3
 from botocore.config import Config
 from django.conf import settings
-from django.core.paginator import Paginator
-from django.db.models import Q
 from django.http import (
     HttpResponse,
     HttpResponseForbidden,
@@ -53,65 +51,6 @@ def validate_json_response(schema, *args, **kwargs):
         return validate_json_schema
 
     return wrapper
-
-
-@csrf_exempt
-@validate_json_response(
-    {
-        "$schema": "http://json-schema.org/draft-07/schema#",
-        "type": "object",
-        "properties": {
-            "aipics": {
-                "type": "array",
-                "items": {
-                    "type": "object",
-                    "properties": {
-                        "ai_pics_id": {"type": "integer"},
-                        "code": {"type": "string"},
-                        "product_name": {"type": "string"},
-                        "company_id": {"type": "integer"},
-                        "url": {"type": "string"},
-                    },
-                    "required": ["ai_pics_id", "code", "product_name", "company_id", "url"],
-                },
-            }
-        },
-        "required": ["aipics"],
-    }
-)
-def get_ai_pics(request):
-    if settings.AI_SHARED_SECRET == '':
-        return HttpResponseForbidden()
-
-    shared_secret = request.POST.get('shared_secret')
-    if shared_secret != settings.AI_SHARED_SECRET:
-        return HttpResponseForbidden()
-
-    page_no = int(request.GET.get('page', 0))
-
-    attachments = (
-        AIAttachment.objects.select_related('ai_pics', 'ai_pics__product')
-        .filter(Q(ai_pics__is_valid=True) | Q(ai_pics__is_valid__isnull=True))
-        .order_by('id')
-    )
-
-    paginator = Paginator(attachments, settings.AI_PICS_PAGE_SIZE)
-
-    aipics = []
-
-    if page_no < paginator.num_pages:
-        for attachment in paginator.page(page_no + 1):
-            aipics.append(
-                {
-                    'ai_pics_id': attachment.ai_pics.id,
-                    'code': attachment.ai_pics.product.code,
-                    'product_name': attachment.ai_pics.product.name,
-                    'company_id': attachment.ai_pics.product.company_id,
-                    'url': attachment.get_absolute_url(),
-                }
-            )
-
-    return JsonResponse({'aipics': aipics})
 
 
 # API v3


### PR DESCRIPTION
Cześć,

My na razie wstrzymaliśmy projekt `pola-ai`, więc wyłączyłem zbieranie zdjęć. Dodatkowo kasuje API do pobieranie tych zdjęć, ponieważ ono konfliktuje z wsparciem dla wielu producentów dla jednego produktu. 

Z wyrazami szacunku,
Kamil Breguła