### PR TITLE
make save buttons stick to the screen bottom

### DIFF
--- a/pola/assets/scss/style.scss
+++ b/pola/assets/scss/style.scss
@@ -4,5 +4,17 @@
 @import 'font-awesome';
 
 .form-group .autocomplete-light-widget {
-    width: 100%;
+  width: 100%;
+}
+
+.sticky {
+  position: fixed;
+  bottom: 20px;
+  left: 50%;
+  transform: translateX(-50%);
+  z-index: 1000;
+  display: flex;
+  gap: 10px; // Space between buttons
+  justify-content: center;
+  width: auto;
 }

--- a/pola/company/templates/company/company_form.html
+++ b/pola/company/templates/company/company_form.html
@@ -30,8 +30,10 @@
             <div class="form-group">
                 <div class="aab controls col-lg-3"></div>
                 <div class="controls col-lg-9">
-                    <input type="submit" name="action" value="Save" class="btn btn-primary" id="submit-id-action">
-                    <input type="reset" name="reset" value="Przywróć poprzednie" class="btn btn-inverse" id="reset-id-reset">
+                    <div class="sticky">
+                        <input type="submit" name="action" value="Save" class="btn btn-primary" id="submit-id-action">
+                        <input type="reset" name="reset" value="Przywróć poprzednie" class="btn btn-inverse" id="reset-id-reset">
+                    </div>
                 </div>
             </div>
         </div>


### PR DESCRIPTION
Dotyczy #501 

Przerobiłem przyciski "Zapisz" oraz "Przywróć poprzednie" aby były zawsze widoczne u dołu ekrany dla formularza dodawania producenta ```/cms/company/create```. Dla innych formularzy zostawiłem tak jak jest, ponieważ są krótkie i ten problem nie powinien ich dotyczyć.

![image](https://github.com/user-attachments/assets/5f6b8a6f-92c0-49fd-aa76-94e6dc5a9269)
