### PR TITLE
Naprawa ładowania plików statycznych na środowisku dev 

### DIFF
--- a/codecov.yml
+++ b/codecov.yml
@@ -1,0 +1,2 @@
+ignore:
+  - "pola/config/settings/local.py"

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -23,7 +23,9 @@ x-pola-backend-common:
     POLA_APP_AWS_S3_AI_PICS_BUCKET_NAME: 'pola-app-ai-pics'
     POLA_APP_AWS_S3_COMPANY_LOGOTYPE_BUCKET_NAME: 'pola-app-company-logotype'
     POLA_APP_AWS_S3_WEB_BUCKET_NAME: 'pola-web-public'
-    POLA_APP_AWS_S3_ENDPOINT_URL: 'http://minio:9000'
+    POLA_APP_AWS_S3_ENDPOINT_URL: 'http://minio:9000' # Używane do komunikacji backendowej Django -> Minio
+    POLA_APP_AWS_S3_CUSTOM_DOMAIN: '${POLA_APP_AWS_S3_CUSTOM_DOMAIN:-localhost:9000}' # Domena publiczna dla Minio
+    POLA_APP_AWS_LOCATION: '${POLA_APP_AWS_LOCATION:-pola-app-public}' # Prefiks ścieżki w URL i w Minio bucket
 
   env_file: .env
   volumes:

--- a/pola/config/settings/local.py
+++ b/pola/config/settings/local.py
@@ -9,11 +9,15 @@ Local settings
 
 # pylint: disable=unused-wildcard-import
 
+import environ
+
 from .tests import *  # noqa: F403
+
+env = environ.Env()
 
 # DEBUG
 # ------------------------------------------------------------------------------
-DEBUG = env.bool('DJANGO_DEBUG', default=True)  # noqa: F405
+DEBUG = env.bool('DJANGO_DEBUG', default=True)
 TEMPLATES[0]['OPTIONS']['debug'] = DEBUG  # noqa: F405
 
 ALLOWED_HOSTS = ['0.0.0.0', 'localhost', 'web', '127.0.0.1']
@@ -31,6 +35,11 @@ DEBUG_TOOLBAR_CONFIG = {
     # 'SHOW_TOOLBAR_CALLBACK': lambda request: True
 }
 
+# Ustawienia minio dla lokalnego developmentu.
+# Domyślnie host 'minio' jest niedostępny z zewnątrz dockera co powodowało błędy z pobieraniem assetów.
+AWS_S3_CUSTOM_DOMAIN = env.str('POLA_APP_AWS_S3_CUSTOM_DOMAIN')  # 'localhost:9000'
+AWS_LOCATION = env.str('POLA_APP_AWS_LOCATION')  # 'pola-app-public'
+AWS_S3_URL_PROTOCOL = 'http:'
 
 # django-extensions
 # ------------------------------------------------------------------------------
@@ -44,5 +53,5 @@ TEST_RUNNER = 'django.test.runner.DiscoverRunner'
 MIDDLEWARE += ('pola.middlewares.SetHostToLocalhost',)
 USE_X_FORWARDED_HOST = True
 
-AI_SHARED_SECRET = env('AI_SHARED_SECRET', default='')  # noqa: F405
+AI_SHARED_SECRET = env('AI_SHARED_SECRET', default='')
 USE_ESCAPED_S3_PATHS = True


### PR DESCRIPTION
Cześć

Często używam aplikacji i dzisiaj postanowiłem sprawdzić jak to dokładnie działa. Używałem [instrukcji](https://github.com/KlubJagiellonski/pola-backend/blob/master/docs/start.rst), ale napotkałem na problemy. 

Mam 3 branche z fixami które doprowadzają codebase do takiego stanu, że postępując zgodnie z instrukcją dostajemy działającą aplikację bez grzebania w kodzie. Mnie kilka bugów nie odstraszyło, ale innych kto wie :wink: 

Pierwszy problem (zauważony już wcześniej w #2235) po uruchomieniu `docker compose up` pliki statyczne się nie ładują.

![minio host](https://github.com/user-attachments/assets/7bbf10d4-0e88-40be-af96-56101eecf55c)


`POLA_APP_AWS_S3_ENDPOINT_URL` jest ustawiony na `http://minio:9000` i to dobrze działa wewnątrz dockera, ale nasza przeglądarka nie potrafi rozwiązać hosta `minio`. Brzydkim hackiem jest edycja `/etc/hosts`, ale raczej nie chcemy dodać takiej instrukcji w instrukcji :smile_cat: 

Po wertowaniu dokumentacji django i django-storages znalazłem `AWS_S3_CUSTOM_DOMAIN`  i `AWS_LOCATION`  dzięki którym można hardcodować własną domenę i lokalizację. Zmiany w kodzie są tylko w pliku local.py, dla środowisk prod i staging mój PR nie wprowadza zmian.

btw próbowałem rozwiązać ten problem przez ustawienie `localhost` w `STATIC_URL` ale tag `static` z django bierze pod uwagę wewnątrzną logikę aktualnego `storage backend` 





