### PR TITLE
Małe poprawki UI

### DIFF
--- a/codecov.yml
+++ b/codecov.yml
@@ -1,0 +1,2 @@
+ignore:
+  - "pola/config/settings/local.py"

--- a/pola/config/urls.py
+++ b/pola/config/urls.py
@@ -9,7 +9,7 @@ from django.views.defaults import (
     permission_denied,
     server_error,
 )
-from django.views.generic import TemplateView
+from django.views.generic import RedirectView, TemplateView
 
 import pola.views as pola_views
 from pola import views_pola_web
@@ -43,6 +43,7 @@ urlpatterns += [
 ]
 # Add CMS views
 urlpatterns += [
+    path('', RedirectView.as_view(pattern_name='home-cms', permanent=True), name='index'),
     path(r'release/', pola_views.ReleaseView.as_view(), name="release"),
     path(r'cms/', pola_views.FrontPageView.as_view(), name="home-cms"),
     path(r'cms/stats', pola_views.StatsPageView.as_view(), name="home-stats"),

--- a/pola/templates/base.html
+++ b/pola/templates/base.html
@@ -39,14 +39,12 @@
                     <span class="icon-bar"></span>
                     <span class="icon-bar"></span>
                 </button>
-                <a class="navbar-brand" href="/">{% trans "Pola" %}</a>
+                <a class="navbar-brand" href="{% url 'home-cms' %}">{% trans "Pola" %}</a>
             </div>
 
             <!-- Collect the nav links, forms, and other content for toggling -->
             <div class="collapse navbar-collapse" id="bs-navbar-collapse-1">
                 <ul class="nav navbar-nav">
-
-                    <li><a href="{% url 'home-cms' %}">{% trans "Start" %}</a></li>
                     <li class="dropdown">
                         <a href="#" class="dropdown-toggle" data-toggle="dropdown" role="button" aria-haspopup="true" aria-expanded="false">GPC <span class="caret"></span></a>
                         <ul class="dropdown-menu">
@@ -125,8 +123,16 @@
     {% else %}
     <script src="{% static 'js/backend.min.js' %}"></script>
     {% endif %}
+    <script>
+        $(document).ready(function() {
+           $(".navbar-nav>li.dropdown>a:first-child").click(function(){
+               $(this).css({
+                   "color": "white",
+               });
+           })
+        });
+    </script>
     {% block javascript %}
-
     {% endblock javascript %}
     {% include 'partiales/google_analytics.html' %}
 </body>

--- a/pola/tests/test_urls.py
+++ b/pola/tests/test_urls.py
@@ -4,6 +4,7 @@ from django.urls import reverse
 
 class TestHome(TestCase):
     def test_should_render_urls(self):
+        self.assertEqual("/", reverse("index"))
         self.assertEqual("/cms/", reverse("home-cms"))
         self.assertEqual("/cms/stats", reverse("home-stats"))
         self.assertEqual("/cms/editors-stats", reverse("home-editors-stats"))


### PR DESCRIPTION
Kontynuując z #4431 

W tym PR naprawiłem

1. Navbar 
Po lewej stronie navbara były dwa przyciski: `Pola` i  `Start`, Przycisk `Pola` prowadził do 

> 404 Nie ma takiej strony 

ponieważ dla `/` nie było zdefiniowanego żadnego widoku. Zostawiłem przycisk `Pola` który jest handlowany przez widok `home-cms` a przycisk `Start` usunąłem.

btw ostatecznie i tak zdefiniowałem widok dla `/` (przekierowanie do `home-cms`) bo np. wylogowując się z aplikacji przekierowuje mnie od razu do `/` czyli do 
> 404 Nie ma takiej strony 

co wygląda słabo. 


2. Nieczytelny tekst na przcisku rozwijanego menu  po kliknięciu

![niewidoczny_text_kolorowy](https://github.com/user-attachments/assets/2ca26083-7838-428f-95cb-ae3a2fd95654)


Teraz tekst jest biały. Chciałem to rozwiązać w CSSie, ale pola korzysta z 10 letniego (!) bootstrapa. Zmiany w _variables.scss nic nie dawały. Ten kawałek kodu żyje własnym życiem i szczerze mówiąc boje się go dotykać.  Rozwiązaniem okazał się monkeypatch w jQuery :smiley_cat: 

![żonk](https://github.com/user-attachments/assets/f791a9ac-3343-4960-9a6b-75ae9192f3ce)

Tutaj w grę wchodzi jedynie rewrite. Polecam https://semantic-ui.com/, też korzysta z gulpa, jest bardzo popularny i cały czas wspierany. To takie middle ground pomiędzy korzystaniem z 10 letniego bootstrapa a appkach czysto SPA.
