### PR TITLE
Naprawa formularzy logowania  na środowisku dev

### DIFF
--- a/codecov.yml
+++ b/codecov.yml
@@ -1,0 +1,2 @@
+ignore:
+  - "pola/config/settings/local.py"

--- a/pola/config/settings/local.py
+++ b/pola/config/settings/local.py
@@ -16,7 +16,8 @@ from .tests import *  # noqa: F403
 DEBUG = env.bool('DJANGO_DEBUG', default=True)  # noqa: F405
 TEMPLATES[0]['OPTIONS']['debug'] = DEBUG  # noqa: F405
 
-ALLOWED_HOSTS = ['0.0.0.0', 'localhost', 'web', '127.0.0.1']
+ALLOWED_HOSTS = ['0.0.0.0', 'localhost', 'web', '127.0.0.1', '172.18.0.1', '172.18.0.2']
+CSRF_TRUSTED_ORIGINS = [f"http://{host}:8080" for host in ALLOWED_HOSTS]
 
 # django-debug-toolbar
 # ------------------------------------------------------------------------------


### PR DESCRIPTION
Kontynuując z #4432 

Logując się po raz pierwszy miałem problem z CSRF. Kliknąłem w link w consoli, ale adres hosta 0.0.0.0 nie był na whiteliście.
Ten PR dodaje wszystkie (najpopularniejsze) opcje dzięki czemu logowanie/POSTowanie działa tak samo na 0.0.0.0 jak i localhost
![PROPO](https://github.com/user-attachments/assets/c43124ff-a075-4fe0-b752-a4bfff9b9fef)
![fob_csrf-fix](https://github.com/user-attachments/assets/7e6d1ff7-c74a-4e6d-a99f-f05caa6c2b07)



