### PR TITLE
Zakładka Statystyki w wersji prod przensoi na panel Lookera

### DIFF
--- a/pola/config/settings/common.py
+++ b/pola/config/settings/common.py
@@ -177,6 +177,7 @@ TEMPLATES = [
                 'django.template.context_processors.tz',
                 'django.contrib.messages.context_processors.messages',
                 # Your stuff: custom template context processors go here
+                'pola.context_processors.app_settings',
             ],
         },
     },
@@ -353,3 +354,12 @@ PRODUKTY_W_SIECI_ENABLE = env.bool("POLA_APP_PRODUKTY_W_SIECI_ENABLE", default=T
 PRODUKTY_W_SIECI = {
     'API_TOKEN': env('POLA_APP_PRODUKTY_W_SIECI_API_TOKEN'),
 }
+
+# CMS / Stats configuration
+# ------------------------------------------------------------------------------
+# External URL for the Stats page used in production deployments.
+# Can be overridden via env var POLA_APP_CMS_STATS_EXTERNAL_URL
+CMS_STATS_EXTERNAL_URL = env.str(
+    'POLA_APP_CMS_STATS_EXTERNAL_URL',
+    default='https://lookerstudio.google.com/u/1/reporting/c8d93b03-e89c-4cbe-be4b-7350ac7d6a67/'
+)

--- a/pola/templates/base.html
+++ b/pola/templates/base.html
@@ -81,7 +81,11 @@
                     {% if perms.pola.change_appconfiguration %}
                         <li><a href="{% url 'app-config' %}">{% trans "Konfiguracja aplikacji" %}</a></li>
                     {% endif %}
-                    <li><a href="{% url 'home-stats' %}">{% trans "Statystyki" %}</a></li>
+                    {% if IS_PRODUCTION and CMS_STATS_EXTERNAL_URL %}
+                        <li><a href="{{ CMS_STATS_EXTERNAL_URL }}" target="_blank" rel="noopener noreferrer">{% trans "Statystyki" %}</a></li>
+                    {% else %}
+                        <li><a href="{% url 'home-stats' %}">{% trans "Statystyki" %}</a></li>
+                    {% endif %}
                 </ul>
 
                 <ul class="nav navbar-nav navbar-right">


### PR DESCRIPTION
Obecnie baza danych Postgres jest na tyle duża, że query w widoku Statystyki trwa zbyt długo i apka pada:
<img width="523" height="218" alt="Screenshot 2025-09-28 at 15 42 22" src="https://github.com/user-attachments/assets/cc2dc21f-3725-4bed-a9d6-0ab6fde32850" />

Do testowania ten widok wciąż się przydaje, ale na produkcji mamy rozwiązanie z ładnymi dashboardami w Lookerze, opartymi na szybkim Big query.

Ten PR proponuje, aby na produkcji ta zakładka otwierała właśnie ten Looker dashboard.