### PR TITLE
eprodukty zmiana w REST API aby dostać NIP

### DIFF
--- a/pola/integrations/produkty_w_sieci.py
+++ b/pola/integrations/produkty_w_sieci.py
@@ -60,7 +60,7 @@ class ProduktyWSieciClient:
         gtin_number: str,
         num_retries: Optional[int] = 5,
     ) -> Optional[ProductBase]:
-        uri = self._base_url.rstrip("/") + "/products/" + gtin_number + "/"
+        uri = self._base_url.rstrip("/") + "/products/" + gtin_number + "?include_local_data=true"
         params = {}
 
         response = self._send_request('get', uri, params=params, num_retries=num_retries)

--- a/pola/tests/cassettes/product_ean13_v2.yaml
+++ b/pola/tests/cassettes/product_ean13_v2.yaml
@@ -9,20 +9,22 @@ interactions:
         Connection:
           - keep-alive
         User-Agent:
-          - python-requests/2.31.0
+          - python-requests/2.32.5
       method: GET
-      uri: https://www.eprodukty.gs1.pl/external_api/v2/products/5901520000059/
+      uri: https://www.eprodukty.gs1.pl/external_api/v2/products/5901520000059?include_local_data=true
     response:
       body:
         string: !!binary |
-          H4sIAAAAAAAAA1VSS27bMBS8CvHWtkxJUGNzF2RV+AOjdlrURhbPIuOypkiCIuEmhk/SY/QIRe/V
-          R7tpEq30hqOZ4TydYB+1XaRupwII4M2El03F89NMYHA5XUWMqQdhkzEDsNgpYs5T//xkNdoDsgWd
-          BzQW2dFJZJ226jrO71ebr4uPt4vpbcHKojGkGDHsVZxjOKgIYgvLGTyQqop3zkZlLxhRZ+tPGdcd
-          7tV9MGS/pVGqvg3aR+3sS5430AztPhGf4vls5YOTqY3LC3Rl636Zdka3IGJIKs+fVdCPWkkQj2h6
-          ggz2ce7kPxAqXtVDXg35h3XJBS9FPSnqyc3NuNqQxS6gle/rILR1nUf7BOL0v67XJtjKF+yZucIV
-          RLXav2TrY1C5E0imYGuUijSRTd2fn62m14NmzTiL60jKMA3k1+JwI8PvX98HjHqkG7s+orlzMnvW
-          9bAec0KPanftAL7F6MVo1L2mLbwZwZkW7amT7YmiX74t8x9Q1VVemPqRQ33Jq/V4cEe0COeH81+w
-          97nVOwIAAA==
+          H4sIAAAAAAAAA41S247aMBD9FctPrQQhl00heVvRalVxWbSwrQqtqiGZTb04dmQ7SwHxJf2MfkLV
+          /+oY6GXfmofIc2Y853jOHHjlhJq29RoNz3mYZmGUxqH/0ox3Ttm5A9daykLhxBMSqqBGiiet3e+U
+          ALUBNqUaA1IB2+oSWC0UnsPJ/Xz5Yfr2ejq6DlgUpJLuOzAVugmYDTqer/hszD9RV3RDrRyqE0al
+          TLIXUjjz0mdFDRXeG0lCVhSWaAsjGie0IiX/w86iTirZdmf1Ru8vFWKvt0BlStiNVmB3Bf3Z8Db+
+          qO50uYdHphvY+BoBOXt9N/88e7Pgz9jHoKqWpJGKxr+tMbpsCzc7QaqVkqTbWbuWouC5My36+B0a
+          8SCw/I1IsG6iywvG4zBOumHcDV8tojAPozzJgiTr9wfxkhjWBlT5fPyEFrpuQO14fvhjzz9vnzcB
+          2zMd6MDbJxpK95OrJO2nZDRB1hn0XvBWBmwBJVJvYCP981sh6LgRLB14EuGIgY8M8RbQXZbmx/fH
+          DiP/6OHaOpBDXXruJOkmg5DQLa7Po+BfnGvyXq/+qzpoZI8fackaGs3qQE843Y389sVJ7BcFv3pR
+          772pFyOAdckuBKNrcLuzf/zoF8QOaQQSHfV4AGlprJWNxqJAVaAfi/RHi3gznlJP2vTME0VXWeKF
+          nrNCVZNbX1zr6XmKN/OIzbT0Iz8ej78Ao/vNYjADAAA=
       headers:
         Allow:
           - GET, HEAD, OPTIONS
@@ -37,7 +39,7 @@ interactions:
         Cross-Origin-Opener-Policy:
           - same-origin
         Date:
-          - Sat, 06 Apr 2024 12:30:52 GMT
+          - Tue, 18 Nov 2025 21:56:25 GMT
         Referrer-Policy:
           - same-origin
         Server:

--- a/pola/tests/test_produkty_w_sieci.py
+++ b/pola/tests/test_produkty_w_sieci.py
@@ -24,6 +24,7 @@ class TestGetProductsFromRealAPI(TestCase):
     def test_should_return_product(self):
         product = produkty_w_sieci_client.get_products(gtin_number=TEST_EAN13)
         assert product.gtinNumber.lstrip("0") == TEST_EAN13.lstrip("0")
+        assert product.company.nip is not None
 
 
 # 🔸 Testy mockowane

--- a/self-management/pages/gs1_api.py
+++ b/self-management/pages/gs1_api.py
@@ -19,7 +19,9 @@ def fetch_products(api_key, params):
 
 def fetch_product_details(api_key, gtin_number):
     """Pobieranie szczegółów produktu."""
-    response = requests.get(f"{API_URL}/products/{gtin_number}", headers={**HEADERS, "X-API-KEY": api_key})
+    response = requests.get(
+        f"{API_URL}/products/{gtin_number}?include_local_data=true", headers={**HEADERS, "X-API-KEY": api_key}
+    )
     return response
 
 


### PR DESCRIPTION
Zgodnie z nowymi wytycznymi:

>  Proszę o dodanie parametru „?include_local_data=true” w URL w zapytaniu API.
> Dotychczasowy URL: https://www.eprodukty.gs1.pl/external_api/v2/products/05904039058658
> Obecny URL z żądaniem dodatkowych danych: https://www.eprodukty.gs1.pl/external_api/v2/products/05904039058658?include_local_data=true

Potrzebne, aby dostać NIP.